### PR TITLE
Map the refactor for item frames and glow item frames (#2123)

### DIFF
--- a/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_1530 net/minecraft/entity/decoration/AbstractDecoratio
 	METHOD method_6888 canStayAttached ()Z
 	METHOD method_6889 onBreak (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
+	METHOD method_6890 (Lnet/minecraft/class_1297;)Z
+		ARG 0 entity
 	METHOD method_6891 getHeightPixels ()I
 	METHOD method_6892 setFacing (Lnet/minecraft/class_2350;)V
 		ARG 1 facing

--- a/mappings/net/minecraft/entity/decoration/GlowItemFrameEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/GlowItemFrameEntity.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_5915 net/minecraft/entity/decoration/GlowItemFrameEntity

--- a/mappings/net/minecraft/entity/decoration/ItemFrameEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/ItemFrameEntity.mapping
@@ -14,6 +14,11 @@ CLASS net/minecraft/class_1533 net/minecraft/entity/decoration/ItemFrameEntity
 		ARG 2 pos
 		ARG 3 facing
 	METHOD method_33340 getAsItemStack ()Lnet/minecraft/class_1799;
+	METHOD method_34240 getRemoveItemSound ()Lnet/minecraft/class_3414;
+	METHOD method_34241 getBreakSound ()Lnet/minecraft/class_3414;
+	METHOD method_34242 getPlaceSound ()Lnet/minecraft/class_3414;
+	METHOD method_34243 getAddItemSound ()Lnet/minecraft/class_3414;
+	METHOD method_34244 getRotateItemSound ()Lnet/minecraft/class_3414;
 	METHOD method_6933 setHeldItemStack (Lnet/minecraft/class_1799;Z)V
 		ARG 1 value
 		ARG 2 update


### PR DESCRIPTION
* Map the refactor for item frames and glow item frames

* Make the names of sound event methods in the ItemFrameEntity class consistent with other sound event methods